### PR TITLE
Added sentence and example about landing page #2

### DIFF
--- a/hostmystudy.html
+++ b/hostmystudy.html
@@ -143,7 +143,7 @@
                   <li><i class="icofont-check"></i>Log-in credentials that you will be able to use to download your videos</li>
                 </ul>
 
-                Each lab must handle their own recruitment, participant management and communication, and incentives. You might choose to recruit for your study on <a href="https://childrenhelpingscience.com/" target="_blank">childrenhelpingscience.com</a> or <a href="https://prolific.co/" target="_blank">Prolific</a>. 
+                Each lab must handle their own recruitment, participant management and communication, and incentives. We highly recommend that you create a <a href="https://liberman.psych.ucsb.edu/node/56" target="_blank">landing page</a> on your own website to provide information about your research to parents before having them click the study link. You might choose to recruit for your study on <a href="https://childrenhelpingscience.com/" target="_blank">childrenhelpingscience.com</a> or <a href="https://prolific.co/" target="_blank">Prolific</a>. 
               </p>
             </div>
           </div>


### PR DESCRIPTION
Reiterated the same information from previous pull request.

Changes made in line 146. Added sentence advising external researchers to use a landing page to direct participants to before having them click the study link. I also added a hyperlink of a landing webpage example.